### PR TITLE
(feat) pass celery task uuid to kwargs for further usage

### DIFF
--- a/celery_pool_asyncio/tracer.py
+++ b/celery_pool_asyncio/tracer.py
@@ -181,6 +181,7 @@ def build_async_tracer(
 
                 # -*- TRACE -*-
                 try:
+                    kwargs['celery_task_uuid'] = uuid
                     coro = fun(*args, **kwargs)
                     coro_task = asyncio.create_task(coro)
 

--- a/examples/update_state.py
+++ b/examples/update_state.py
@@ -1,0 +1,46 @@
+# coding: utf8
+
+import asyncio
+import os
+from random import randint
+
+from update_state_app import celery, simple_task, celery_states
+
+NUM_CELERY_TASKS = 10
+
+
+async def run_simple():
+    tasks = []
+    for _ in range(NUM_CELERY_TASKS):
+        times = randint(3, 6)
+        tasks.append({
+            'times': times,
+            'state': None,
+            'current': 0,
+            'uuid': str(await simple_task.delay(times)),
+            'completed': False
+        })
+    while True:
+        await asyncio.sleep(0.1)
+        all_done = True
+        os.system('clear')
+        for task in tasks:
+            result = celery.AsyncResult(task['uuid'])
+            task['state'] = result.state
+            if result.state == celery_states.FAILURE:
+                pass
+            else:
+                if isinstance(result.info, dict):
+                    task['current'] = result.info['time']
+                if task['current'] >= task['times'] or result.state == celery_states.SUCCESS:
+                    task['completed'] = True
+                else:
+                    all_done = False
+            label = [task['uuid'], task['state'], str(task['times']), str(task['current'])]
+            print(' - '.join(label))
+        if all_done:
+            break
+    print('Completed')
+
+if __name__ == "__main__":
+    asyncio.run(run_simple())

--- a/examples/update_state_app.py
+++ b/examples/update_state_app.py
@@ -1,0 +1,40 @@
+# coding: utf8
+
+import asyncio
+
+# Importing Celery
+from celery import Celery
+from celery import states as celery_states
+
+# Importing Async
+import celery_pool_asyncio
+celery_pool_asyncio.__package__
+
+
+# Configure
+celery = Celery(__name__)
+celery.conf.broker_url = 'redis://localhost:6379/10'
+celery.conf.result_backend = 'redis://localhost:6379/10'
+
+
+# Override task class
+class ContextTask(celery.Task):
+    async def __call__(self, *args, **kwargs):
+        # Updating state, so flower can show that it was started
+        self.update_state(task_id=kwargs['celery_task_uuid'], state=celery_states.STARTED)
+        return await self.run(*args, **kwargs)
+
+
+celery.Task = ContextTask
+
+
+# Define simple task
+@celery.task(bind=True)
+async def simple_task(task, times, **kwargs):
+    time = 0
+    while time < times:
+        await asyncio.sleep(1)
+        time += 1
+        task.update_state(task_id=kwargs['celery_task_uuid'], state='INPROGRESS', meta={'time': time})
+        print(f'{kwargs["celery_task_uuid"]} [{times} / {time}]')
+    return {'time': time}


### PR DESCRIPTION
Hello!

Thank you for your package.

I have some problems if i run many same tasks with storing state of task progress:

- I can't use `self.update_state` with `@celery.task(bind=True)`;
It works, but updates only last task state. Even I run `update_state` in different task request. It happens because `task.update_state` (without `task_id` argument) calls `task.request` but it returns only top element of task request stack.

- Not all tasks turned for `started` state;
Some random task turned for `started` state but not all of them.

So i added one more kwarg parameter in trace.py that provides task uuid for further usage.

I added example that shows how it works — pretty simple, but impossible without this argument. I understand that you store examples in different repository but don't know how to show this technique in one place, so i added it here.

Thanks once more for your work.
